### PR TITLE
Feature/complete the look

### DIFF
--- a/app/components/AddToCartButton.tsx
+++ b/app/components/AddToCartButton.tsx
@@ -1,5 +1,6 @@
 import {type FetcherWithComponents} from '@remix-run/react';
 import {CartForm, type OptimisticCartLineInput} from '@shopify/hydrogen';
+import {Button} from './ui-primatives/button';
 
 export function AddToCartButton({
   analytics,
@@ -12,7 +13,7 @@ export function AddToCartButton({
   children: React.ReactNode;
   disabled?: boolean;
   lines: Array<OptimisticCartLineInput>;
-  onClick?: () => void;
+  onClick?: (() => void) | ((e: React.MouseEvent<HTMLButtonElement>) => void);
 }) {
   return (
     <CartForm route="/cart" inputs={{lines}} action={CartForm.ACTIONS.LinesAdd}>
@@ -23,13 +24,14 @@ export function AddToCartButton({
             type="hidden"
             value={JSON.stringify(analytics)}
           />
-          <button
+          <Button
             type="submit"
             onClick={onClick}
             disabled={disabled ?? fetcher.state !== 'idle'}
-          >
-            {children}
-          </button>
+            style="primary"
+            label="add to cart"
+            ariaLabel="add to cart"
+          />
         </>
       )}
     </CartForm>

--- a/app/components/ui-primatives/button.tsx
+++ b/app/components/ui-primatives/button.tsx
@@ -1,14 +1,30 @@
 import React from 'react';
 
 interface WrapperProps {
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick:
+    | (() => void)
+    | ((e: React.MouseEvent<HTMLButtonElement>) => void)
+    | undefined;
   type: 'submit' | 'button';
   ariaLabel: string;
   label: string;
   style: 'primary' | 'secondary';
+  disabled?: boolean;
 }
 
-export function Button({label, onClick, type, ariaLabel, style}: WrapperProps) {
+export function Button({
+  label,
+  onClick,
+  type,
+  ariaLabel,
+  style,
+  disabled,
+}: WrapperProps) {
+  const handleClick = onClick
+    ? (e: React.MouseEvent<HTMLButtonElement>) => {
+        if (typeof onClick === 'function') onClick(e);
+      }
+    : undefined;
   return (
     <button
       className={`cursor-pointer transition-bg duration-200  py-1 px-3 rounded-md ${
@@ -18,7 +34,8 @@ export function Button({label, onClick, type, ariaLabel, style}: WrapperProps) {
       }`}
       type={type}
       aria-label={ariaLabel}
-      onClick={onClick}
+      onClick={handleClick}
+      disabled={disabled}
     >
       <span aria-hidden="true">{label}</span>
     </button>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -40,9 +40,9 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 export function links() {
   return [
-    {rel: 'stylesheet', href: tailwindCss},
     {rel: 'stylesheet', href: resetStyles},
     {rel: 'stylesheet', href: appStyles},
+    {rel: 'stylesheet', href: tailwindCss},
     {
       rel: 'preconnect',
       href: 'https://cdn.shopify.com',

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -101,12 +101,12 @@ export default function Product() {
   );
 
   // Only create completeTheLookSelectedVariant if completeTheLookProduct exists
-  const completeTheLookSelectedVariant = completeTheLookProduct
-    ? useOptimisticVariant(
-        completeTheLookProduct.selectedOrFirstAvailableVariant,
-        getAdjacentAndFirstAvailableVariants(completeTheLookProduct),
-      )
-    : null;
+  const completeTheLookSelectedVariant = useOptimisticVariant(
+    completeTheLookProduct?.selectedOrFirstAvailableVariant ?? null,
+    completeTheLookProduct
+      ? getAdjacentAndFirstAvailableVariants(completeTheLookProduct)
+      : null,
+  );
 
   // Only get completeTheLookProductOptions if completeTheLookProduct exists
   const completeTheLookProductOptions = completeTheLookProduct

--- a/app/styles/reset.css
+++ b/app/styles/reset.css
@@ -1,16 +1,6 @@
 body {
-  font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    'Open Sans',
-    'Helvetica Neue',
-    sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   margin: 0;
   padding: 0;
 }
@@ -47,10 +37,10 @@ h5 {
   margin-top: 0.5rem;
 }
 
-p {
-  font-size: 1rem;
+/* p {
+  @apply text-[100px];
   line-height: 1.4;
-}
+} */
 
 a {
   color: #000;


### PR DESCRIPTION
### Complete the Look Feature

#### Summary
This PR introduces a "Complete the Look" feature on the product page. The primary objective was to experiment with Shopify metafields and implement a simple functionality showcasing related products.

#### Changes
- Added a query to fetch and display "Complete the Look" products using metafields.
- Updated the product loader to include metafield data.
- Created a new UI component for displaying related products in a grid format.
- Refactored existing components for better reusability, such as a shared `Button` component.
- Improved type safety and cleaned up code by enhancing props interfaces.

#### Notes
- This feature is mostly exploratory, focusing on metafields integration.
- The "Complete the Look" section will render only if relevant metafield data is available.

#### Testing
- Verified that the "Complete the Look" section appears for products with associated metafields.
- Tested the add-to-cart functionality for the related products.
- Confirmed proper fallback behavior for products without metafields.

#### Demo
![complete-the-look](https://github.com/user-attachments/assets/2bd5a7c1-c5d5-487e-baef-9ac53970c441)
